### PR TITLE
Pipeline fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -221,16 +221,17 @@ runs:
         username: ${{ inputs.repo-username }}
         password: ${{ inputs.repo-password }}
 
-
     - name: Get Repo
+      shell: bash
+      if: inputs.publish-image == 'true'
       run: |
-        
         export REPO=${{ inputs.image-repo }}/${{ inputs.repo-username }}
         if [ ${{inputs.use-dockerhub}} ]; then
           echo "REPO=${{ inputs.image-repo }}" >> "$GITHUB_ENV"
         else
           echo "REPO=${{ inputs.image-repo }}/${{ inputs.repo-username }}" >> "$GITHUB_ENV"
         fi
+
     # Push the image with the user-defined tag
     - name: Build and push
       if: inputs.publish-image == 'true'
@@ -247,8 +248,8 @@ runs:
           fi
 
     # Sign images
-    - name: Sign tagged image
-      if: inputs.publish-image == 'true' && inputs.use-dockerhub != 'true'
+    - name: Sign tagged image(s)
+      if: inputs.publish-image == 'true'
       shell: bash
       run: |        
         cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${{ env.REPO }}/${{ inputs.image-name }}:${{ inputs.image-tag }}@${{ steps.build.outputs.digest }}

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
   image-name:
     description: "The name of the image to build."
     required: true
+  add-latest-tag:
+    description: "Adds the latest tag to the build."
+    required: false
+    default: false
   image-tag:
     description: "The tag to build the image with - provide a matrix to build against multiple tags as each will need to be SBOM'd, scanned and signed independently."
     required: true
@@ -199,7 +203,6 @@ runs:
       uses: sigstore/cosign-installer@v3.2.0
 
     ### USING DOCKERHUB ###
-
     # Login into registry
     - name: Login to GitHub Container Registry
       if: inputs.publish-image == 'true' && inputs.use-dockerhub == 'true'
@@ -208,32 +211,7 @@ runs:
         username: ${{ inputs.repo-username }}
         password: ${{ inputs.repo-password }}
 
-    # Push the image with the user-defined tag + latest
-    - name: Build and push
-      if: inputs.publish-image == 'true' && inputs.use-dockerhub == 'true'
-      id: build-docker-latest
-      uses: docker/build-push-action@v4
-      with:
-        platforms: linux/amd64
-        push: true
-        file: "${{inputs.dockerfile-path}}/Dockerfile"
-        tags: |
-          ${{ inputs.image-repo }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
-          ${{ inputs.image-repo }}/${{ inputs.image-name }}:latest
-
-    # Sign images
-    - name: Sign tagged image
-      if: inputs.publish-image == 'true' && inputs.use-dockerhub == 'true'
-      shell: bash
-      run: |
-        cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${{ inputs.image-repo }}/${{ inputs.image-name }}:latest@${{ steps.build-docker-latest.outputs.digest }}
-      env:
-        COSIGN_PRIVATE_KEY: ${{inputs.cosign-private-key}}
-        COSIGN_PASSWORD: ${{inputs.cosign-password}}
-        COSIGN_EXPERIMENTAL: "true"
-
     ### USING ALT REPO ###
-
     # Login into registry
     - name: Login to GitHub Container Registry
       if: inputs.publish-image == 'true' && inputs.use-dockerhub != 'true'
@@ -245,7 +223,7 @@ runs:
 
     # Push the image with the user-defined tag + latest
     - name: Build and push
-      if: inputs.publish-image == 'true' && inputs.use-dockerhub != 'true'
+      if: inputs.publish-image == 'true'
       id: build
       uses: docker/build-push-action@v4
       with:
@@ -253,15 +231,32 @@ runs:
         push: true
         file: "${{inputs.dockerfile-path}}/Dockerfile"
         tags: |
-          ${{ inputs.image-repo }}/${{ inputs.repo-username }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
-          ${{ inputs.image-repo }}/${{ inputs.repo-username }}/${{ inputs.image-name }}:latest
+          export REPO=${{ inputs.image-repo }}/${{ inputs.repo-username }}
+          if [ ${{inputs.use-dockerhub}} ]; then
+            REPO=${{ inputs.image-repo }}
+          fi
+          
+          ${REPO}/${{ inputs.image-name }}:${{ inputs.image-tag }}
+          
+          if [ ${{inputs.add-latest-tag}} ]; then
+            ${REPO}/${{ inputs.image-name }}:latest
+          fi
 
     # Sign images
     - name: Sign tagged image
       if: inputs.publish-image == 'true' && inputs.use-dockerhub != 'true'
       shell: bash
       run: |
-        cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${{ inputs.image-repo }}/${{ inputs.repo-username }}/${{ inputs.image-name }}:latest@${{ steps.build-latest.outputs.digest }}
+        export REPO=${{ inputs.image-repo }}/${{ inputs.repo-username }}
+        if [ ${{inputs.use-dockerhub}} ]; then
+          REPO=${{ inputs.image-repo }}
+        fi
+        
+        cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${REPO}/${{ inputs.image-name }}:${{ inputs.image-tag }}@${{ steps.build.outputs.digest }}
+        
+        if [ ${{inputs.add-latest-tag}} ]; then
+          cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${REPO}/${{ inputs.image-name }}:latest@${{ steps.build.outputs.digest }}
+        fi
       env:
         COSIGN_PRIVATE_KEY: ${{inputs.cosign-private-key}}
         COSIGN_PASSWORD: ${{inputs.cosign-password}}

--- a/action.yml
+++ b/action.yml
@@ -263,7 +263,7 @@ runs:
       run: |        
         cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${{ env.REPO }}/${{ inputs.image-name }}:${{ inputs.image-tag }}@${{ steps.build.outputs.digest }}
         
-        if [ ${{inputs.add-latest-tag}} ]; then
+        if [ ${{inputs.add-latest-tag}} == true ]; then
           cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${{ env.REPO }}/${{ inputs.image-name }}:latest@${{ steps.build-latest.outputs.digest }}
         fi
       env:

--- a/action.yml
+++ b/action.yml
@@ -243,9 +243,18 @@ runs:
         file: "${{inputs.dockerfile-path}}/Dockerfile"
         tags: |
           ${{ env.REPO }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
-          if [ ${{inputs.add-latest-tag}} ]; then
-            ${{ env.REPO }}/${{ inputs.image-name }}:latest
-          fi
+
+      # Push the image with the latest tag
+    - name: Build and push
+      if: inputs.publish-image == 'true' && inputs.add-latest-tag == 'true'
+      id: build-latest
+      uses: docker/build-push-action@v4
+      with:
+        platforms: linux/amd64
+        push: true
+        file: "${{inputs.dockerfile-path}}/Dockerfile"
+        tags: |
+          ${{ env.REPO }}/${{ inputs.image-name }}:latest
 
     # Sign images
     - name: Sign tagged image(s)
@@ -255,7 +264,7 @@ runs:
         cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${{ env.REPO }}/${{ inputs.image-name }}:${{ inputs.image-tag }}@${{ steps.build.outputs.digest }}
         
         if [ ${{inputs.add-latest-tag}} ]; then
-          cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${{ env.REPO }}/${{ inputs.image-name }}:latest@${{ steps.build.outputs.digest }}
+          cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${{ env.REPO }}/${{ inputs.image-name }}:latest@${{ steps.build-latest.outputs.digest }}
         fi
       env:
         COSIGN_PRIVATE_KEY: ${{inputs.cosign-private-key}}

--- a/action.yml
+++ b/action.yml
@@ -221,7 +221,17 @@ runs:
         username: ${{ inputs.repo-username }}
         password: ${{ inputs.repo-password }}
 
-    # Push the image with the user-defined tag + latest
+
+    - name: Get Repo
+      run: |
+        
+        export REPO=${{ inputs.image-repo }}/${{ inputs.repo-username }}
+        if [ ${{inputs.use-dockerhub}} ]; then
+          echo "REPO=${{ inputs.image-repo }}" >> "$GITHUB_ENV"
+        else
+          echo "REPO=${{ inputs.image-repo }}/${{ inputs.repo-username }}" >> "$GITHUB_ENV"
+        fi
+    # Push the image with the user-defined tag
     - name: Build and push
       if: inputs.publish-image == 'true'
       id: build
@@ -231,31 +241,20 @@ runs:
         push: true
         file: "${{inputs.dockerfile-path}}/Dockerfile"
         tags: |
-          export REPO=${{ inputs.image-repo }}/${{ inputs.repo-username }}
-          if [ ${{inputs.use-dockerhub}} ]; then
-            REPO=${{ inputs.image-repo }}
-          fi
-          
-          ${REPO}/${{ inputs.image-name }}:${{ inputs.image-tag }}
-          
+          ${{ env.REPO }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
           if [ ${{inputs.add-latest-tag}} ]; then
-            ${REPO}/${{ inputs.image-name }}:latest
+            ${{ env.REPO }}/${{ inputs.image-name }}:latest
           fi
 
     # Sign images
     - name: Sign tagged image
       if: inputs.publish-image == 'true' && inputs.use-dockerhub != 'true'
       shell: bash
-      run: |
-        export REPO=${{ inputs.image-repo }}/${{ inputs.repo-username }}
-        if [ ${{inputs.use-dockerhub}} ]; then
-          REPO=${{ inputs.image-repo }}
-        fi
-        
-        cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${REPO}/${{ inputs.image-name }}:${{ inputs.image-tag }}@${{ steps.build.outputs.digest }}
+      run: |        
+        cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${{ env.REPO }}/${{ inputs.image-name }}:${{ inputs.image-tag }}@${{ steps.build.outputs.digest }}
         
         if [ ${{inputs.add-latest-tag}} ]; then
-          cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${REPO}/${{ inputs.image-name }}:latest@${{ steps.build.outputs.digest }}
+          cosign sign --tlog-upload=${{inputs.cosign-tlog}} --yes --key env://COSIGN_PRIVATE_KEY ${{ env.REPO }}/${{ inputs.image-name }}:latest@${{ steps.build.outputs.digest }}
         fi
       env:
         COSIGN_PRIVATE_KEY: ${{inputs.cosign-private-key}}


### PR DESCRIPTION
I was doing a couple of silly things around the latest tagging so this brings it back in and improves the workflow to reduce duplicate steps and parse out the repo before any push or signing happens.

Tests:
https://github.com/eschercloudai/container-security-action-demo/actions/runs/7058945329/job/19215931430
